### PR TITLE
Upgrade to for Statamic 5.x, and provide as an addon

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -1,11 +1,12 @@
 ## Installing
 
-- Install by copying the files into `site/addons/Wikilinks`.
-- That's it.
+```
+composer require statamic/wikilinks
+```
 
 ## Usage
 
-Wikilinks is a simple modifier that seeks out any content wrapped in [braces] and automatically links it to other entries or pages with the same title (or other field of your choosing).
+Wikilinks provides a simple modifier that seeks out any content wrapped in [braces] and automatically links it to other entries or pages with the same title (or other field of your choosing).
 
 ### Example
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,12 @@
-# Wikilinks ![Statamic v2](https://img.shields.io/badge/statamic-v2-blue.svg?style=flat-square)
+# Wikilinks ![Statamic v5](https://img.shields.io/badge/statamic-v5-blue.svg?style=flat-square)
 
-## Modifier
 
-Wikilinks is a simple modifier that seeks out any content wrapped in [braces] and automatically links it to other entries or pages with the same title (or other field of your choosing).
+Wikilinks is an add-on for Statamic 5.x that enables Wiki style [links] in the content of your site.
+
+It provides a simple modifier that seeks out any content wrapped in [braces] and automatically links it to other entries or pages with the same title (or other field of your choosing).
 
 ```
 {{ content | wikilinks }}
 ```
+
+See the Documentation for more details of usage.

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,37 @@
+{
+    "name": "statamic/wikilinks",
+    "autoload": {
+        "psr-4": {
+            "Statamic\\Wikilinks\\": "src"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Statamic\\Wikilinks\\Tests\\": "tests"
+        }
+    },
+    "require": {
+        "statamic/cms": "^5.0"
+    },
+    "require-dev": {
+        "orchestra/testbench": "^9.0"
+    },
+    "config": {
+        "allow-plugins": {
+            "pixelfear/composer-dist-plugin": true
+        }
+    },
+    "extra": {
+        "statamic": {
+            "name": "Wikilinks",
+            "description": "Wikilinks addon"
+        },
+        "laravel": {
+            "providers": [
+                "Statamic\\Wikilinks\\ServiceProvider"
+            ]
+        }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
+}

--- a/meta.yaml
+++ b/meta.yaml
@@ -1,6 +1,0 @@
-name: Wikilinks
-version: "1.0"
-description: 'Autolinks content wrapped in [braces], like a wiki.'
-url: https://statamic.com/marketplace/addons/wikilinks
-developer: Statamic
-developer_url: https://statamic.com

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Statamic\Wikilinks;
+
+use Statamic\Wikilinks\Modifiers\WikilinksModifier;
+use Statamic\Providers\AddonServiceProvider;
+
+class ServiceProvider extends AddonServiceProvider
+{
+    public function bootAddon()
+    {
+        //
+    }
+
+    protected $modifiers = [
+        WikilinksModifier::class,
+    ];
+}


### PR DESCRIPTION
This is a first attempt at upgrading Wikilinks to Statamic 5.x, and providing it as an addon.

Becoming an addon provides an easier installation route, but also opens up the possibility of extending the functionality.

At the moment, this upgrade provides exactly the same functionality as the previous version.